### PR TITLE
Add dockerfile to api-application-deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12.9-alpine3.21
+
+WORKDIR /app
+
+RUN apk add --no-cache postgresql-dev
+
+COPY ./requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", "--log-config", "logging_config.json"]


### PR DESCRIPTION
This pull request includes the addition of a new `Dockerfile` to set up a Python-based environment for the application. The file specifies the base image, working directory, necessary dependencies, and the command to run the application.

Key changes:

* **Dockerfile creation**:
  * Added a new `Dockerfile` to set up a Python environment using `python:3.12.9-alpine3.21` as the base image.
  * Configured the working directory to `/app` and installed `postgresql-dev` dependency.
  * Included steps to copy `requirements.txt` and install dependencies using `pip`.
  * Exposed port `8080` and set the command to run the application using `uvicorn` with the specified host, port, and logging configuration.