### PR TITLE
Create fork-repository.yml

### DIFF
--- a/.github/workflows/fork-repository.yml
+++ b/.github/workflows/fork-repository.yml
@@ -1,0 +1,30 @@
+name: Fork Core Repository
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight
+
+jobs:
+  fork-core-repo:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout current repository
+      uses: actions/checkout@v3
+
+    - name: Clone the core repository
+      run: git clone https://github.com/PI-coffeeBreak/core.git
+
+    - name: Set up Git
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+    - name: Push to current repository
+      run: |
+        cd core
+        git remote set-url origin https://github.com/PI-coffeeBreak/api-application-deployment.git
+        git push origin main --force


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the forking of the core repository. The workflow is configured to run daily at midnight and includes steps to clone the core repository, set up Git, and push the changes to the current repository.

New GitHub Actions workflow:

* [`.github/workflows/fork-repository.yml`](diffhunk://#diff-8956ad261d02f2b4958bf0ca97a43ec74cf4745a85e22b876484d0eb9f67516dR1-R30): Added a new workflow named "Fork Core Repository" that runs daily at midnight to automate the forking process of the core repository. The workflow includes steps for checking out the current repository, cloning the core repository, setting up Git, and pushing the changes to the current repository.